### PR TITLE
Call createRelease via `rest` object

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            await github.repos.createRelease({
+            await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: 'v' + process.env['package-version'],


### PR DESCRIPTION
This was a breaking change as part of upgrading to V5 of `github-script`.

See:
https://github.com/actions/github-script#breaking-changes-in-v5

which also links to:
https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/tag/v5.0.0