### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Dash components for Gov UK",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This shouldn't change any functionality, and is designed only to test that the latest repository cleaning (#33 , #32 , #31) hasn't broken any functionality within Python dashboards.