### PR TITLE
ignore dashboard.css in any repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,4 +296,4 @@ src/jl
 Project.toml
 
 # CSS from the package repo
-*dashboard.css
+**dashboard.css


### PR DESCRIPTION
Correct mistake from previous PR in git-ignoring dashboard.css if it's included for testing