### PR TITLE
improve visual accessibility for autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ __These are the default instructions__
 - [Review your code](./review_checklist.md)
 
 ### Create a production build and publish:
-1. Update the `version` property of the `package.json` file in the syle of Major.Minor.Patch, e.g. 1.2.3
+1. Update the `version` property of the `package.json` file in the style of Major.Minor.Patch, e.g. 1.2.3
     - Major - any breaking changes to previous functionality.
     - Minor - additional functionality that doesn't effect backward compatibility. When updated the patch version should be reset to zero. eg. 2.3.1 goes to 2.4.0 for minor update.
     - Patch - bug fixes that don't effect backward compatibility.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Dash components for Gov UK",
   "repository": {
     "type": "git",

--- a/src/lib/fragments/AutoComplete.react.js
+++ b/src/lib/fragments/AutoComplete.react.js
@@ -631,7 +631,7 @@ const AutoComplete = (props) => {
 	}
 
 	return (
-		<div>
+		<div className={showErrorMessage ? 'govuk-form-group govuk-form-group--error' : ''}>
 			{showErrorMessage && (<p className="govuk-error-message">{errorMessage}</p>)}
 
 			<div className={wrapperClassName} onKeyDown={handleKeyDown} style={style}>


### PR DESCRIPTION
Accessibility for dropdown error message
PR for ticket https://trello.com/c/Avj9jdv9

- Have implemented this formatting for the autocomplete component which means the line does not also wrap the label ("Select a local authority). 
- To wrap the label we would have to implement in dropdown which might require quite a lot more work to figure out how to access the autocomplete showErrorMessage state from the dropdown. 
- After discussion with Joe it was decided displaying the line only for the autocomplete was acceptable.

![image](https://user-images.githubusercontent.com/112866399/210840430-04ebfddb-1810-473a-b3d6-9854abd395c4.png)