### PR TITLE
fix accordion content shown or hidden when heading toggled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Dash components for Gov UK",
   "repository": {
     "type": "git",

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -10,7 +10,7 @@ const EventOrigin = {
   SHOW_ALL_BUTTON: "show all button",
 };
 
-// const AccordionContentClassName = "govuk-accordion__section-content";
+const AccordionContentClassName = "govuk-accordion__section-content";
 const AccordionButtonClassName = "accordion-button govuk-accordion__section-button";
 
 class Accordion extends Component {
@@ -220,7 +220,7 @@ class Accordion extends Component {
           </h2>
         </div>
         <div
-          // className={AccordionContentClassName}
+          className={AccordionContentClassName}
           id={contentId}
           tabIndex="0" //set this to make the content focusable for default tab key navigation events
           aria-label={`Content at level ${index}`}

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -10,7 +10,7 @@ const EventOrigin = {
   SHOW_ALL_BUTTON: "show all button",
 };
 
-const AccordionContentClassName = "govuk-accordion__section-content";
+const AccordionContentClassName = "govuk-accordion__section-content accordion-padding";
 const AccordionButtonClassName = "accordion-button govuk-accordion__section-button";
 
 class Accordion extends Component {

--- a/src/lib/fragments/accordion.css
+++ b/src/lib/fragments/accordion.css
@@ -14,12 +14,12 @@ input[type=reset]:focus {
 }
 
 .js-enabled .govuk-accordion__section-content.accordion-padding {
-  padding-bottom: 15px; 
+  padding-bottom: 5px; 
 }
 
 @media (min-width: 40.0625em) {
   .js-enabled .govuk-accordion__section-content.accordion-padding {
-    padding-bottom: 20px; /* override for larger screens */
+    padding-bottom: 10px; /* override for larger screens */
   }
 }
 

--- a/src/lib/fragments/accordion.css
+++ b/src/lib/fragments/accordion.css
@@ -12,3 +12,14 @@ input[type=reset]:focus {
   margin: 0 1rem 0 0;
   line-height: initial;
 }
+
+.js-enabled .govuk-accordion__section-content.accordion-padding {
+  padding-bottom: 15px; 
+}
+
+@media (min-width: 40.0625em) {
+  .js-enabled .govuk-accordion__section-content.accordion-padding {
+    padding-bottom: 20px; /* override for larger screens */
+  }
+}
+


### PR DESCRIPTION
Fix bug so that accordion content is shown or hidden when heading toggled. 
Also add css classes to override default padding in accordion section content css class.
PIC 1:
![image](https://github.com/communitiesuk/gov-uk-dash-react-components/assets/112866399/2c3cffc4-5c48-4670-89c2-172fa2d071a9)

PIC 2:
![image](https://github.com/communitiesuk/gov-uk-dash-react-components/assets/112866399/27e123dc-023e-434f-9930-06402ebefb01)

