### PR TITLE
Accessibility audit jump to banners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.19.4",
+  "version": "1.19.5",
 
   "description": "Dash components for Gov UK",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.19.9",
+  "version": "1.19.3",
 
   "description": "Dash components for Gov UK",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.19.7",
+  "version": "1.19.8",
 
   "description": "Dash components for Gov UK",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.19.6",
+  "version": "1.19.7",
 
   "description": "Dash components for Gov UK",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.19.2",
+  "version": "1.19.3",
 
   "description": "Dash components for Gov UK",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.19.3",
+  "version": "1.19.4",
 
   "description": "Dash components for Gov UK",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.19.5",
+  "version": "1.19.6",
 
   "description": "Dash components for Gov UK",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk_gov_dash_components",
-  "version": "1.19.8",
+  "version": "1.19.9",
 
   "description": "Dash components for Gov UK",
   "repository": {

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -234,7 +234,7 @@ class Accordion extends Component {
         > <div>
             {bannerSection != null ? <div className="change-log-banner govuk-!-margin-bottom-2" onClick={() => this.jumpToAccordionContentSection(bannerSection)}>
               <div className="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary" style={{backgroundColor:'white', color: '#1d70b8'}}
+                <button id='accordion-button2' role="button" className="govuk-button govuk-button--secondary"
                 >
                   Jump to {bannerSectionHeading}
                 </button>

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -234,7 +234,7 @@ class Accordion extends Component {
         > <div>
             {bannerSection != null ? <div className="change-log-banner govuk-!-margin-bottom-2" onClick={() => this.jumpToAccordionContentSection(bannerSection)}>
               <div className="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary"
+                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary" style={{backgroundColor:'white', color: '#1d70b8'}}
                 >
                   Jump to {bannerSectionHeading}
                 </button>

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -234,7 +234,7 @@ class Accordion extends Component {
         > <div>
             {bannerSection != null ? <div className="change-log-banner govuk-!-margin-bottom-2" onClick={() => this.jumpToAccordionContentSection(bannerSection)}>
               <div className="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-                <button id='accordion-button2' role="button" className="govuk-button govuk-button--secondary"
+                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary"
                 >
                   Jump to {bannerSectionHeading}
                 </button>

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -234,7 +234,7 @@ class Accordion extends Component {
         > <div>
             {bannerSection != null ? <div className="change-log-banner govuk-!-margin-bottom-2" onClick={() => this.jumpToAccordionContentSection(bannerSection)}>
               <div className="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary"
+                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary" style={{color:'#0b0c0c'}}
                 >
                   Jump to {bannerSectionHeading}
                 </button>

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -234,10 +234,10 @@ class Accordion extends Component {
         > <div>
             {bannerSection != null ? <div className="change-log-banner govuk-!-margin-bottom-2" onClick={() => this.jumpToAccordionContentSection(bannerSection)}>
               <div className="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-                <div id='accordion-button' className="govuk-button accordion-button"
+                <button id='accordion-button' role="button" className="govuk-button accordion-button"
                 >
                   Jump to {bannerSectionHeading}
-                </div>
+                </button>
                 {/* alt text here if wanted */}
               </div>
             </div> : null}

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -234,7 +234,7 @@ class Accordion extends Component {
         > <div>
             {bannerSection != null ? <div className="change-log-banner govuk-!-margin-bottom-2" onClick={() => this.jumpToAccordionContentSection(bannerSection)}>
               <div className="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary" style={{color:'#0b0c0c'}}
+                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary"
                 >
                   Jump to {bannerSectionHeading}
                 </button>

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -234,7 +234,7 @@ class Accordion extends Component {
         > <div>
             {bannerSection != null ? <div className="change-log-banner govuk-!-margin-bottom-2" onClick={() => this.jumpToAccordionContentSection(bannerSection)}>
               <div className="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-                <button id='accordion-button' role="button" className="govuk-button accordion-button"
+                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary"
                 >
                   Jump to {bannerSectionHeading}
                 </button>

--- a/src/lib/fragments/Accordion.react.js
+++ b/src/lib/fragments/Accordion.react.js
@@ -234,7 +234,7 @@ class Accordion extends Component {
         > <div>
             {bannerSection != null ? <div className="change-log-banner govuk-!-margin-bottom-2" onClick={() => this.jumpToAccordionContentSection(bannerSection)}>
               <div className="govuk-body-s govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-                <button id='accordion-button' role="button" className="govuk-button govuk-button--secondary"
+                <button id='accordion-jump-to-button' role="button" className="govuk-button govuk-button--secondary"
                 >
                   Jump to {bannerSectionHeading}
                 </button>

--- a/src/lib/fragments/accordion.css
+++ b/src/lib/fragments/accordion.css
@@ -7,8 +7,8 @@ input[type=reset]:focus {
 
 
 #accordion-button {
-  /* background-color: white;
-  color: #1d70b8; */
+  /* background-color: white; */
+  color: #000000; 
   margin: 0 1rem 0 0;
   line-height: initial;
 }

--- a/src/lib/fragments/accordion.css
+++ b/src/lib/fragments/accordion.css
@@ -1,3 +1,10 @@
+.accordion-button:focus,
+input[type=submit]:focus,
+input[type=reset]:focus {
+  background-color: #F3F2F1 !important;
+  outline: transparent !important;
+}
+
 #accordion-button {
   color: #000000; 
   margin: 0 1rem 0 0;

--- a/src/lib/fragments/accordion.css
+++ b/src/lib/fragments/accordion.css
@@ -1,13 +1,4 @@
-.accordion-button:focus,
-input[type=submit]:focus,
-input[type=reset]:focus {
-  background-color: #F3F2F1 !important;
-  outline: transparent !important;
-}
-
-
 #accordion-button {
-  /* background-color: white; */
   color: #000000; 
   margin: 0 1rem 0 0;
   line-height: initial;

--- a/src/lib/fragments/accordion.css
+++ b/src/lib/fragments/accordion.css
@@ -7,8 +7,8 @@ input[type=reset]:focus {
 
 
 #accordion-button {
-  background-color: white;
-  color: #1d70b8;
+  /* background-color: white;
+  color: #1d70b8; */
   margin: 0 1rem 0 0;
   line-height: initial;
 }

--- a/src/lib/fragments/accordion.css
+++ b/src/lib/fragments/accordion.css
@@ -5,7 +5,7 @@ input[type=reset]:focus {
   outline: transparent !important;
 }
 
-#accordion-button {
+#accordion-jump-to-button {
   color: #000000; 
   margin: 0 1rem 0 0;
   line-height: initial;


### PR DESCRIPTION
Users can now interact with "jump to" buttons using keyboard - changed div to button and applied role=button.
Applied govuk-button--secondary class to "jump to" buttons to allow for hover functionality.

![image](https://github.com/communitiesuk/gov-uk-dash-react-components/assets/95618509/8ca395fd-40bb-471f-9937-342bfbb347fa)
