### PR TITLE
optional props for change log banner, though - still appears if no da…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "uk_gov_dash_components",
-    "version": "1.22.7",
+    "version": "1.22.8",
     "description": "Dash components for Gov UK",
     "repository": {
         "type": "git",

--- a/src/lib/components/ChangeLogBanner.react.js
+++ b/src/lib/components/ChangeLogBanner.react.js
@@ -15,9 +15,9 @@ ChangeLogBanner.propTypes = {
     updates: PropTypes.arrayOf(
         PropTypes.shape({
             type: PropTypes.string.isRequired,           // Type of change
-            date: PropTypes.string.isRequired,           // Date of the change
+            date: PropTypes.string,                      // Optional date of the change
             heading: PropTypes.string.isRequired,        // Heading or title of the change
-            link: PropTypes.string.isRequired,           // Link associated with the change
+            link: PropTypes.string,                     // Optional link associated with the change
             linkTitle: PropTypes.string,                 // Optional title of the link
         })
     ),  // Marked as required because the component uses it directly

--- a/src/lib/fragments/ChangeLogBanner.react.js
+++ b/src/lib/fragments/ChangeLogBanner.react.js
@@ -17,12 +17,16 @@ const ChangeLogBanner = ({ updates = defaultProps.updates }) => {
                                 <strong className="govuk-tag change-log-banner-tag">
                                     {update.type}
                                 </strong>
-                                <time dateTime={update.date}>
-                                    {format(new Date(update.date), 'd MMMM yyyy')}
-                                </time> &mdash; {update.heading}
-                                <a className={"govuk-link-white govuk-!-margin-left-1"} href={update.link}>
+                                {update.date && (
+                                    <time dateTime={update.date}>
+                                        {format(new Date(update.date), 'd MMMM yyyy')}
+                                    </time> 
+                                )} &mdash; {update.heading} 
+                                {update.link && (
+                                    <a className={"govuk-link-white govuk-!-margin-left-1"} href={update.link}>
                                     {update.linkTitle ? update.linkTitle : 'More'}
-                                </a>
+                                    </a>
+                                )}
                             </div>
                         </div>
                     )


### PR DESCRIPTION
…te passed

For change log banner make date and link optional parameters. Note: there is a slight issue where if a date isn't passed in it currently leaves a dash "-" though, this won't be a direct issue for now, more a bug fix for a future ticket given the priority of getting this new update banner out which will include a date now.