### PR TITLE
add option value to html for scraping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "uk_gov_dash_components",
-    "version": "1.22.8",
+    "version": "1.23.0",
     "description": "Dash components for Gov UK",
     "repository": {
         "type": "git",

--- a/src/lib/components/Tabs.react.js
+++ b/src/lib/components/Tabs.react.js
@@ -59,7 +59,7 @@ Tabs.propTypes = {
      defaultTab: PropTypes.number,
 
      /**
-      * Array of accordion children.
+      * Array of tab children.
       */
      children: PropTypes.arrayOf(PropTypes.node),
 };

--- a/src/lib/fragments/AutoComplete.react.js
+++ b/src/lib/fragments/AutoComplete.react.js
@@ -722,6 +722,7 @@ const AutoComplete = (props) => {
 							<li
 								aria-selected={isFocus === index ? 'true' : 'false'}
 								className={option.disabled === true ? `${optionClassName} ${optionClassName}--disabled` : `${optionClassName}${optionModifierFocused}${optionModifierOdd}`}
+								option-value={option.value}
 								dangerouslySetInnerHTML={{ __html: templateSuggestion(option) + iosPosinsetHtml }}
 								id={`${id}__option--${index}`}
 								key={index}


### PR DESCRIPTION
add option value to html for scraping - so that we can see the la code in the html and use it to navigate to la pages.